### PR TITLE
Update electron to 1.8.2-beta5

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "css-loader": "0.28.7",
     "del-cli": "^1.1.0",
     "dotenv": "4.0.0",
-    "electron": "~1.7.9",
+    "electron": "~> 1.8.2-beta5",
     "electron-builder": "^19.48.3",
     "eslint": "4.13.1",
     "eslint-config-react-app": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,9 +30,9 @@
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.9.4.tgz#cdeb6bcbef9b6c584374b81aa7f48ecf3da404fa"
 
-"@types/node@^7.0.18":
-  version "7.0.48"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.48.tgz#24bfdc0aa82e8f6dbd017159c58094a2e06d0abb"
+"@types/node@^8.0.24":
+  version "8.10.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.8.tgz#794cba23cc9f8d9715f6543fa8827433b5f5cd3b"
 
 abab@^1.0.3:
   version "1.0.4"
@@ -2301,11 +2301,11 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.28:
   version "1.3.28"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz#8dd4e6458086644e9f9f0a1cf32e2a1f9dffd9ee"
 
-electron@~1.7.9:
-  version "1.7.9"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.9.tgz#add54e9f8f83ed02f6519ec10135f698b19336cf"
+"electron@~> 1.8.2-beta5":
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.4.tgz#cca8d0e6889f238f55b414ad224f03e03b226a38"
   dependencies:
-    "@types/node" "^7.0.18"
+    "@types/node" "^8.0.24"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 


### PR DESCRIPTION
The version of electron we're using has a vulnerability report on it. So this updates it.